### PR TITLE
Quickfix jenkins deadlock

### DIFF
--- a/Jenkinsfile.internal
+++ b/Jenkinsfile.internal
@@ -28,7 +28,7 @@ pipeline {
     }
 
     agent {
-        label 'docker'
+        label 'docker && linux' // linux only to keep windows docker runners free, so they can run the systemTests job
     }
 
     environment {


### PR DESCRIPTION
**Description**

When e.g. dependabot rebases many of its pull requests, these build jobs get stuck in an deadlock on our internal Jenkins Server. This is just a quickfix for a fast improvement of the situation, as a bigger restructuring of the Jenkinsfile is needed to do it properly.

**Solution/Acceptance Criteria**
- [ ] The pipeline runs only on one OS of our docker runners, so the systemTests pipeline then can use the runners with the other OS
