### PR TITLE
Reenable auto merge by pat (#198)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,16 +2,17 @@ name: Auto merge for GH Actions
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' && contains( github.event.pull_request.labels.*.name, 'github_actions') }}
     steps:
+      - name: Authenticate cli with a PAT
+        run: echo "${{ secrets.MERGE_TOKEN }}" | gh auth login --with-token
       - name: Enable auto-merge for Dependabot GitHub Actions PRs
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Seems like we have overridden the change to use a personal access token for the GitHub Actions update auto merge action by accident.
The Pull Request enables the use of a personal access token instead of the GITHUB_TOKEN, as a merge by github-actions bot does not trigger github actions to run on the ne commit.

relates #100 